### PR TITLE
do fix up of tables first with ROW_FORMAT=DYNAMIC

### DIFF
--- a/utf8mb4_converter.drush.inc
+++ b/utf8mb4_converter.drush.inc
@@ -12,21 +12,26 @@ function utf8mb4_converter_drush_command() {
 
 function drush_utf8mb4_converter_utf8mb4_convert() {
   foreach (db_query("show tables")->fetchCol() as $table) {
+    $table_ok = TRUE;
+    try {
+      utf8mb4_converter_fix_table($table);
+    } catch(Exception $e) {
+      $table_ok = FALSE;
+      drush_log($table . ': ' . $e->getMessage(), 'warning');
+      watchdog_exception('utf8mb4_converter', $e);
+    }
     $schema = utf8mb4_converter_get_column_iterator($table);
     foreach ($schema as $column_name => $column_def){
       try {
         $results[] = utf8mb4_converter_fix_column($column_def, $table);
       } catch(Exception $e) {
+        $table_ok = FALSE;
         drush_log($table . ': ' . $e->getMessage(), 'warning');
         watchdog_exception('utf8mb4_converter', $e);
       }
     }
-    try {
-      utf8mb4_converter_fix_table($table);
+    if ($table_ok) {
       drush_log($table, 'ok');
-    } catch(Exception $e) {
-      drush_log($table . ': ' . $e->getMessage(), 'warning');
-      watchdog_exception('utf8mb4_converter', $e);
     }
   }
 }

--- a/utf8mb4_converter.module
+++ b/utf8mb4_converter.module
@@ -183,6 +183,12 @@ function utf8mb4_converter_convert_all_tables() {
 }
 
 function utf8mb4_converter_convert_table_batch($table, &$context) {
+  try {
+    utf8mb4_converter_fix_table($table);
+  } catch(Exception $e) {
+    drupal_set_message($table . ': ' . $e->getMessage(), 'error');
+    watchdog_exception('utf8mb4_converter', $e);
+  }
   $schema = utf8mb4_converter_get_column_iterator($table);
   foreach ($schema as $column_name => $column_def){
     try {
@@ -191,12 +197,6 @@ function utf8mb4_converter_convert_table_batch($table, &$context) {
       drupal_set_message($table . ': ' . $e->getMessage(), 'error');
       watchdog_exception('utf8mb4_converter', $e);
     }
-  }
-  try {
-    utf8mb4_converter_fix_table($table);
-  } catch(Exception $e) {
-    drupal_set_message($table . ': ' . $e->getMessage(), 'error');
-    watchdog_exception('utf8mb4_converter', $e);
   }
   $context['results'][] = $table;
   $context['message'] = t('Now processing %table', ['%table' => $table]);
@@ -210,6 +210,12 @@ function utf8mb4_converter_convert_table_finished($success, $results, $operation
  * @param $tablename
  */
 function utf8mb4_converter_convert_table($tablename) {
+  try {
+    utf8mb4_converter_fix_table($tablename);
+  } catch(Exception $e) {
+    drupal_set_message($tablename . ': ' . $e->getMessage(), 'error');
+    watchdog_exception('utf8mb4_converter', $e);
+  }
   $schema = utf8mb4_converter_get_column_iterator($tablename);
   foreach ($schema as $column_name => $column_def){
     try {
@@ -218,12 +224,6 @@ function utf8mb4_converter_convert_table($tablename) {
       drupal_set_message($tablename . ': ' . $e->getMessage(), 'error');
       watchdog_exception('utf8mb4_converter', $e);
     }
-  }
-  try {
-    utf8mb4_converter_fix_table($tablename);
-  } catch(Exception $e) {
-    drupal_set_message($tablename . ': ' . $e->getMessage(), 'error');
-    watchdog_exception('utf8mb4_converter', $e);
   }
   $table = utf8mb4_converter_create_column_table($tablename);
   echo $table['data']['data']['data'];
@@ -252,7 +252,7 @@ function utf8mb4_converter_get_longest_field_length($tablename, $columnname) {
  * @return DatabaseStatment object
  */
 function utf8mb4_converter_fix_table($table) {
-  $sql = "ALTER TABLE `{$table}` CONVERT to CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;";
+  $sql = "ALTER TABLE `{$table}` CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci ROW_FORMAT=DYNAMIC;";
   $sql .= " REPAIR TABLE `{$table}`;";
   $sql .= " OPTIMIZE TABLE `{$table}`;";
   return db_query($sql);


### PR DESCRIPTION
As described in [1] a table's row format must be either ROW_FORMAT=DYNAMIC or ROW_FORMAT=COMPRESSED in order for the "innodb_large_prefix=1" setting to have any effect.

Quote:

For InnoDB tables that use COMPRESSED or DYNAMIC row format, you can enable the innodb_large_prefix option to allow index key prefixes longer than 767 bytes (up to 3072 bytes). Creating such tables also requires the option values innodb_file_format=barracuda and innodb_file_per_table=true.) In this case, enabling the innodb_large_prefix option would allow you to index a maximum of 1024 or 768 characters for utf8 or utf8mb4 columns, respectively. For related information, see Section 14.5.7, “Limits on InnoDB Tables”.

[1] https://dev.mysql.com/doc/refman/5.6/en/charset-unicode-upgrading.html
